### PR TITLE
Changing project location in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,6 +2,6 @@
 
 A docker image with the latest sbcl and roswell ready an waiting for you!
 
-Install your project in `/root/quicklisp/local-projects/${SYSTEM_NAME}` for easy loading!
+Install your project in `/root/.roswell/local-projects/${SYSTEM_NAME}` for easy loading!
 
 This image is available on the Docker Hub at [this location](https://hub.docker.com/r/fisxoj/common-lisp-sbcl/).


### PR DESCRIPTION
When I build a Dockerfile based on this one I needed to put the project in `/root/.roswell/local-projects/${SYSTEM_NAME}` instead of `/root/quicklisp/local-projects/${SYSTEM_NAME}`. Is this true for you too?
